### PR TITLE
Spelling fixes and ability to override default post_status

### DIFF
--- a/src/WP_Model.php
+++ b/src/WP_Model.php
@@ -913,6 +913,9 @@ Abstract Class WP_Model implements JsonSerializable
 	// -----------------------------------------------------
 	/**
 	 * Save the model and all of it's associated data
+	 *
+	 * @param Array $overrides  List of parameters to override for wp_insert_post(), such as post_status
+	 *
 	 * @return Object $this
 	 */
 	public function save($overrides = [])

--- a/src/WP_Model.php
+++ b/src/WP_Model.php
@@ -30,16 +30,16 @@ Abstract Class WP_Model implements JsonSerializable
 	public $dirty  = FALSE;
 	public $booted = FALSE;
 
-	
+
 
 	/**
 	 * Create a new instace with data
-	 * 
+	 *
 	 * @param array $insert
 	 * @return void
 	 */
 	public function __construct(Array $insert = [])
-	{ 	
+	{
 		if(!empty($this->default)){
 			foreach($this->default as $attribute => $value){
 				$this->data[$attribute] = $value;
@@ -50,7 +50,7 @@ Abstract Class WP_Model implements JsonSerializable
 			if(in_array($attribute, $this->attributes)){
 				$this->set($attribute, $value);
 			}
-			
+
 			if(!empty($this->taxonomies)){
 				if(in_array($attribute, $this->taxonomies)){
 					if(is_array($value)){
@@ -114,7 +114,7 @@ Abstract Class WP_Model implements JsonSerializable
 
 	/**
 	 * Register the post type using the propery $postType as the post type
-	 * 
+	 *
 	 * @param  array  $args  see: register_post_type()
 	 * @return void
 	 */
@@ -134,7 +134,7 @@ Abstract Class WP_Model implements JsonSerializable
 
 	/**
 	 * Create a new model with data, save and return the model
-	 * 
+	 *
 	 * @param array $insert
 	 */
 	public static function insert(Array $insert = []){
@@ -147,7 +147,7 @@ Abstract Class WP_Model implements JsonSerializable
 	// -----------------------------------------------------
 	/**
 	 * Fire event if the event method exists
-	 * 
+	 *
 	 * @param  string $event event name
 	 * @return bool
 	 */
@@ -160,7 +160,7 @@ Abstract Class WP_Model implements JsonSerializable
 
 		return FALSE;
 	}
-	
+
 
 	// -----------------------------------------------------
 	// HOOKS
@@ -174,7 +174,7 @@ Abstract Class WP_Model implements JsonSerializable
 	{
 		add_action(('save_post'), [get_called_class(), 'onSave'], 9999999999);
 	}
- 
+
  	/**
 	 * Remove hooks
 	 *
@@ -187,7 +187,7 @@ Abstract Class WP_Model implements JsonSerializable
 
 	/**
 	 * save_post hook: Triggers save method for a given post
-	 * 
+	 *
 	 * @param int $ID
 	 * @return void
 	 */
@@ -206,7 +206,7 @@ Abstract Class WP_Model implements JsonSerializable
 	// -----------------------------------------------------
 	/**
 	 * Create a new model without calling the constructor.
-	 * 
+	 *
 	 * @return object
 	 */
 	protected static function newWithoutConstructor(){
@@ -217,7 +217,7 @@ Abstract Class WP_Model implements JsonSerializable
 
 	/**
 	 * Returns the post type
-	 * 
+	 *
 	 * @return string
 	 *
 	 * @throws \Exception
@@ -237,7 +237,7 @@ Abstract Class WP_Model implements JsonSerializable
 
 	/**
 	 * Returns a new model
-	 * 
+	 *
 	 * @return object
 	 */
 	public static function newInstance($insert = [])
@@ -247,8 +247,8 @@ Abstract Class WP_Model implements JsonSerializable
 	}
 
 	/**
-	 * Returns an array representaion of the model for serialization 
-	 * 
+	 * Returns an array representaion of the model for serialization
+	 *
 	 * @return array
 	 */
 	public function jsonSerialize()
@@ -257,7 +257,7 @@ Abstract Class WP_Model implements JsonSerializable
     }
 
     /**
-     * Returns TRUE if $attribute is in the $virtual array 
+     * Returns TRUE if $attribute is in the $virtual array
      * and has a corresponding vitaul property method
      *
      * @param  string $attribute
@@ -266,7 +266,7 @@ Abstract Class WP_Model implements JsonSerializable
 	public function isVirtualProperty($attribute)
 	{
 		return (isset($this->virtual) &&
-			in_array($attribute, $this->virtual) && 
+			in_array($attribute, $this->virtual) &&
 			method_exists($this, ('_get'. ucfirst($attribute))));
 	}
 
@@ -278,11 +278,11 @@ Abstract Class WP_Model implements JsonSerializable
 	 */
 	public function getVirtualProperty($attribute)
 	{
-		return call_user_func([$this, ('_get'. ucfirst($attribute))]);  
+		return call_user_func([$this, ('_get'. ucfirst($attribute))]);
 	}
 
 	/**
-     * Returns TRUE if $attribute is in the $filter array 
+     * Returns TRUE if $attribute is in the $filter array
      * and has a corresponding filter property method
      *
      * @param  string $attribute
@@ -303,7 +303,7 @@ Abstract Class WP_Model implements JsonSerializable
 	 */
 	public function getFilterProperty($attribute)
 	{
-		return call_user_func_array([$this, ('_filter'. ucfirst($attribute))], [$this->get($attribute)]);  
+		return call_user_func_array([$this, ('_filter'. ucfirst($attribute))], [$this->get($attribute)]);
 	}
 
 
@@ -312,7 +312,7 @@ Abstract Class WP_Model implements JsonSerializable
 	// -----------------------------------------------------
 	/**
 	 * Returns meta value for a meta key
-	 * 
+	 *
 	 * @param  string meta_key
 	 * @return string
 	 */
@@ -322,7 +322,7 @@ Abstract Class WP_Model implements JsonSerializable
 
 	/**
 	 * Set meta value for a meta key
-	 * 
+	 *
 	 * @param  string meta_key
 	 * @param  string meta_value
 	 * @return void
@@ -332,8 +332,8 @@ Abstract Class WP_Model implements JsonSerializable
 	}
 
 	/**
-	 * Delete meta's meta 
-	 * 
+	 * Delete meta's meta
+	 *
 	 * @param  string meta_key
 	 * @return void
 	 */
@@ -347,7 +347,7 @@ Abstract Class WP_Model implements JsonSerializable
 	// -----------------------------------------------------
 	/**
 	 * Get property of model or $default
-	 * 
+	 *
 	 * @param  property $attribute [description]
 	 * @param  property $default
 	 * @return mixed
@@ -365,7 +365,7 @@ Abstract Class WP_Model implements JsonSerializable
 
 	/**
 	 * Set propert of the model
-	 * 
+	 *
 	 * @param string $attribute
 	 * @param string $value
 	 * @return void
@@ -421,7 +421,7 @@ Abstract Class WP_Model implements JsonSerializable
 	// Taxonomies
 	// -----------------------------------------------------
 	/**
-	 * 
+	 *
 	 * @return void
 	 */
 	public function getTaxonomy($attribute, $param = NULL)
@@ -518,13 +518,13 @@ Abstract Class WP_Model implements JsonSerializable
 	// -----------------------------------------------------
 	/**
 	 * Check if the post exists by Post ID
-	 * 
+	 *
 	 * @param  string|inte  $ID   Post ID
 	 * @param  bool 		$postTypeSafe Require post to be the same post type as the model
 	 * @return bool
 	 */
 	public static function exists($ID, $postTypeSafe = TRUE)
-	{	
+	{
 		if($postTypeSafe){
 			if(
 				(get_post_status($ID) !== FALSE) &&
@@ -540,7 +540,7 @@ Abstract Class WP_Model implements JsonSerializable
 
 	/**
 	 * Returns the original post object
-	 * 
+	 *
 	 * @return WP_Post
 	 */
 	public function post()
@@ -550,7 +550,7 @@ Abstract Class WP_Model implements JsonSerializable
 
 	/**
 	 * Returns TRUE if the model's post has an associated featured image
-	 * 
+	 *
 	 * @return bool
 	 */
 	public function hasFeaturedImage()
@@ -560,7 +560,7 @@ Abstract Class WP_Model implements JsonSerializable
 
 	/**
 	 * Get model's featured image or return $default if it does not exist
-	 * 
+	 *
 	 * @param  string $default
 	 * @return string
 	 */
@@ -572,7 +572,7 @@ Abstract Class WP_Model implements JsonSerializable
 
 	/**
 	 * Returns an asoc array representaion of the model
-	 * 
+	 *
 	 * @return array
 	 */
 	public function toArray()
@@ -606,7 +606,7 @@ Abstract Class WP_Model implements JsonSerializable
 
 	/**
 	 * Get the model for a single page or in the loop
-	 * 
+	 *
 	 * @return object|NULL
 	 */
 	public static function single()
@@ -616,7 +616,7 @@ Abstract Class WP_Model implements JsonSerializable
 
 	/**
 	 * returns the post's permalink
-	 * 
+	 *
 	 * @return string
 	 */
 	public function permalink()
@@ -630,7 +630,7 @@ Abstract Class WP_Model implements JsonSerializable
 	// ----------------------------------------------------
 	/**
 	 * Find model by it's post ID
-	 * 
+	 *
 	 * @param  int $ID
 	 * @return Object|NULL
 	 */
@@ -648,7 +648,7 @@ Abstract Class WP_Model implements JsonSerializable
 
 	/**
 	 * Get model by ID without booting the model
-	 * 
+	 *
 	 * @param  int $ID
 	 * @return Object|NULL
 	 */
@@ -665,7 +665,7 @@ Abstract Class WP_Model implements JsonSerializable
 
 	/**
 	 * Find the model by ID. If the post does not exist throw.
-	 * 
+	 *
 	 * @param  int $id
 	 * @return object
 	 *
@@ -682,7 +682,7 @@ Abstract Class WP_Model implements JsonSerializable
 
 	/**
 	 * Returns all models
-	 * 
+	 *
 	 * @param  string $limit
 	 * @return array
 	 */
@@ -705,7 +705,7 @@ Abstract Class WP_Model implements JsonSerializable
 
 	/**
 	 * Retun an array of models as asoc array. Key by $value
-	 * 
+	 *
 	 * @param  string  $value
 	 * @param  array   $models
 	 * @return array
@@ -722,7 +722,7 @@ Abstract Class WP_Model implements JsonSerializable
 			if(is_int($model) || $model instanceof WP_Post){
 				$model = Self::find($model->ID);
 			}
-			
+
 			$return[$model->ID] = $model->$value;
 		}
 
@@ -814,7 +814,7 @@ Abstract Class WP_Model implements JsonSerializable
 
 		$arr = [];
 		foreach($query->get_posts() as $key => $post){
-			$arr[] = Self::find($post->ID); 
+			$arr[] = Self::find($post->ID);
 		}
 
 		return $arr;
@@ -832,7 +832,7 @@ Abstract Class WP_Model implements JsonSerializable
 
 		foreach($ids as $key => $id){
 			if(Self::exists($id)){
-				$results[] = Self::find($id); 
+				$results[] = Self::find($id);
 			}
 		}
 
@@ -915,13 +915,13 @@ Abstract Class WP_Model implements JsonSerializable
 	 * Save the model and all of it's associated data
 	 * @return Object $this
 	 */
-	public function save()
+	public function save($overrides = [])
 	{
 		$this->triggerEvent('saving');
 
-		$overwrite = [
+		$overwrite = array_merge($overrides, [
 			'post_type' => Self::getPostType()
-		];
+		]);
 
 		Self::removeHooks();
 
@@ -956,7 +956,7 @@ Abstract Class WP_Model implements JsonSerializable
 
 		foreach($this->attributes as $attribute){
 			$this->setMeta($attribute, $this->get($attribute, ''));
-		}	
+		}
 
 		$this->setMeta('_id', $this->ID);
 		$this->triggerEvent('saved');

--- a/src/WP_Model.php
+++ b/src/WP_Model.php
@@ -122,12 +122,12 @@ Abstract Class WP_Model implements JsonSerializable
 	{
 		$postType = Self::getPostType();
 
-		$defualts = [
+		$defaults = [
 			'public' => TRUE,
 			'label' => ucfirst($postType)
 		];
 
-		register_post_type($postType, array_merge($defualts, $args));
+		register_post_type($postType, array_merge($defaults, $args));
 
 		Self::addHooks();
 	}
@@ -912,7 +912,7 @@ Abstract Class WP_Model implements JsonSerializable
 	// SAVE
 	// -----------------------------------------------------
 	/**
-	 * Save the model and all of it's asociated data
+	 * Save the model and all of it's associated data
 	 * @return Object $this
 	 */
 	public function save()
@@ -926,22 +926,22 @@ Abstract Class WP_Model implements JsonSerializable
 		Self::removeHooks();
 
 		if(is_integer($this->ID)){
-			$defualts = [
+			$defaults = [
 				'ID'           => $this->ID,
 				'post_title'   => $this->title,
 				'post_content' => ($this->content !== NULL)? $this->content :  ' ',
 			];
 
-			wp_update_post(array_merge($defualts, $overwrite));
+			wp_update_post(array_merge($defaults, $overwrite));
 		}else{
 			$this->triggerEvent('inserting');
-			$defualts = [
+			$defaults = [
 				'post_status'  => 'publish',
 				'post_title'   => $this->title,
 				'post_content' => ($this->content !== NULL)? $this->content :  ' ',
 			];
 
-			$this->ID = wp_insert_post(array_merge($defualts, $overwrite));
+			$this->ID = wp_insert_post(array_merge($defaults, $overwrite));
 			$this->_post = get_post($this->ID);
 			$this->triggerEvent('inserted');
 		}
@@ -985,13 +985,13 @@ Abstract Class WP_Model implements JsonSerializable
 	{
 		$this->triggerEvent('hardDeleting');
 
-		$defualts = [
+		$defaults = [
 			'ID'           => $this->ID,
 			'post_title'   => '',
 			'post_content' => '',
 		];
 
-		wp_update_post($defualts);
+		wp_update_post($defaults);
 
 		foreach($this->attributes as $attribute){
 			$this->deleteMeta($attribute);


### PR DESCRIPTION
This has been a very useful class, but I ran into an issue where I needed the post_status to not get set to publish on creation, and didn't see a way around that with the current code. PHPStorm also removed the trailing whitespace, so apologies for all those innocuous changes.