### PR TITLE
Pass more args to WP_Query

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -170,6 +170,13 @@ Product::query()
     ->tax('taxonomy', 'field', 'operator', 'terms')
 ```
 
+#### Params() 
+An array of additional arguments for WP_Query.
+```php
+Product::query()
+    ->params(['orderby' => 'meta_value', 'order' => 'ASC])
+```
+
 #### Example
 
 ```php
@@ -185,6 +192,7 @@ $products = Product::query()
     ->tax('category', ['office', 'home'])
     ->tax('quality', 'slug', 'high')
     ->tax('county', 'term_id', 'NOT IN', [1, 5])
+    ->params(['orderby' => 'meta_value menu_order title'])
     ->execute();
 ```
 


### PR DESCRIPTION
Added ability to pass additional arguments to WP_Query call when using query builder syntax.