### PR TITLE
Declare $_params property 

### DIFF
--- a/src/WP_Model.php
+++ b/src/WP_Model.php
@@ -15,6 +15,7 @@ Abstract Class WP_Model implements JsonSerializable
 	public $ID;
 	public $_post;
 	public $_where;
+	public $_params;
 
 	public $attributes = [];
 	public $prefix = '';


### PR DESCRIPTION
Declare $_params property to allow correct addition of new WP_Query arguments.

Without the declaration any additional params passed to the `params` method are not preserved in future method calls.